### PR TITLE
contractAddress fix in addEvents.js (Wrong Index)

### DIFF
--- a/addEvents.js
+++ b/addEvents.js
@@ -3,7 +3,8 @@ require("dotenv").config()
 const contractAddresses = require("./constants/networkMapping.json")
 let chainId = process.env.chainId || 31337
 let moralisChainId = chainId == "31337" ? "1337" : chainId
-const contractAddress = contractAddresses[chainId]["NftMarketplace"][0]
+const contractAddressArray = contractAddresses[chainId]["NftMarketplace"]
+const contractAddress = contractAddressArray[contractAddressArray.length - 1]
 
 const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL
 const appId = process.env.NEXT_PUBLIC_APP_ID


### PR DESCRIPTION
Currently, we have `contractAddress = contractAddresses[chainId]["NftMarketplace"][0]` but this will always get us the 0th index or the oldest element of the array. If a new address for the contract is added, it will be at 1st index, that is, `contractAddresses[chainId]["NftMarketplace"][1]` but we are still using 0th index. 

So it should be
 ```
const contractAddressArray = contractAddresses[chainId]["NftMarketplace"];
const contractAddress = contractAddressArray[contractAddressArray.length - 1];
```

P.S. :-
Sorry for the bad commit message, it is my first time creating a pull request, didn't know that we have a feature to communicate so I tried to include all the details in the commit message itself!