### PR TITLE
Remove wrapping div

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -26,16 +26,14 @@ export default function Home() {
                             const { price, nftAddress, tokenId, marketplaceAddress, seller } =
                                 nft.attributes
                             return (
-                                <div>
-                                    <NFTBox
-                                        price={price}
-                                        nftAddress={nftAddress}
-                                        tokenId={tokenId}
-                                        marketplaceAddress={marketplaceAddress}
-                                        seller={seller}
-                                        key={`${nftAddress}${tokenId}`}
-                                    />
-                                </div>
+                                <NFTBox
+                                    price={price}
+                                    nftAddress={nftAddress}
+                                    tokenId={tokenId}
+                                    marketplaceAddress={marketplaceAddress}
+                                    seller={seller}
+                                    key={`${nftAddress}${tokenId}`}
+                                />
                             )
                         })
                     )


### PR DESCRIPTION
Hi Patrick, first of all thanks for being awesome.

By removing the `div` that wraps the `NFTBox` component, you get rid of the error in the browser console that says:

```
Warning: Each child in a list should have a unique "key" prop
```

Cheers